### PR TITLE
Fixes compatible with ros2 humble

### DIFF
--- a/src/allan_variance_ros2/CMakeLists.txt
+++ b/src/allan_variance_ros2/CMakeLists.txt
@@ -53,9 +53,10 @@ src/AllanVarianceComputor.cpp
 )
 # target_link_libraries(${PROJECT_NAME} ${COLCON_PACKAGE_DEPENDENCIES})
 ament_target_dependencies(${PROJECT_NAME} ${COLCON_PACKAGE_DEPENDENCIES})
+target_link_libraries(${PROJECT_NAME} Boost::filesystem)
 
 add_executable(allan_variance src/allan_variance.cpp)
-target_link_libraries(allan_variance ${PROJECT_NAME} )
+target_link_libraries(allan_variance ${PROJECT_NAME} Boost::filesystem)
 
 add_executable(plot_imu src/plot_imu.cpp)
 target_link_libraries(plot_imu PRIVATE ${PROJECT_NAME} rerun_sdk)

--- a/src/allan_variance_ros2/scripts/analysis.py
+++ b/src/allan_variance_ros2/scripts/analysis.py
@@ -14,6 +14,10 @@ import numpy as np
 from scipy.optimize import curve_fit
 
 
+# Plain YAML float; numpy scalars repr() as np.float64(...) otherwise.
+def yaml_float(x):
+	return str(float(np.asarray(x).item()))
+
 def line_func(x, m, b):
 	return m * x + b
 
@@ -139,8 +143,8 @@ worst_accel_white_noise = np.amax([accel_wn_intercept_x, accel_wn_intercept_y, a
 worst_accel_random_walk = np.amax([accel_rr_intercept_x, accel_rr_intercept_y, accel_rr_intercept_z])
 
 yaml_file.write("#Accelerometer\n")
-yaml_file.write("accelerometer_noise_density: " + repr(worst_accel_white_noise) + " \n")
-yaml_file.write("accelerometer_random_walk: " + repr(worst_accel_random_walk) + " \n")
+yaml_file.write("accelerometer_noise_density: " + yaml_float(worst_accel_white_noise) + "\n")
+yaml_file.write("accelerometer_random_walk: " + yaml_float(worst_accel_random_walk) + "\n")
 yaml_file.write("\n")
 
 
@@ -229,17 +233,17 @@ worst_gyro_random_walk = np.amax([gyro_rr_intercept_x, gyro_rr_intercept_y, gyro
 
 yaml_file.write("#Gyroscope\n")
 # Convert back to radians here
-yaml_file.write("gyroscope_noise_density: " + repr(worst_gyro_white_noise * np.pi / 180) + " \n")
-yaml_file.write("gyroscope_random_walk: " + repr(worst_gyro_random_walk * np.pi / 180) + " \n")
+yaml_file.write("gyroscope_noise_density: " + yaml_float(worst_gyro_white_noise * np.pi / 180) + "\n")
+yaml_file.write("gyroscope_random_walk: " + yaml_float(worst_gyro_random_walk * np.pi / 180) + "\n")
 yaml_file.write("\n")
 
 
 if args.config:
-	yaml_file.write("rostopic: " + repr(rostopic) + " \n")
-	yaml_file.write("update_rate: " + repr(update_rate) + " \n")
+	yaml_file.write("rostopic: " + repr(rostopic) + "\n")
+	yaml_file.write("update_rate: " + yaml_float(update_rate) + "\n")
 else:
 	yaml_file.write("rostopic: " + repr(rostopic) + " #Make sure this is correct\n")
-	yaml_file.write("update_rate: " + repr(update_rate) + " #Make sure this is correct\n")
+	yaml_file.write("update_rate: " + yaml_float(update_rate) + " #Make sure this is correct\n")
 yaml_file.write("\n")
 yaml_file.close()
 

--- a/src/allan_variance_ros2/scripts/plot_imu.py
+++ b/src/allan_variance_ros2/scripts/plot_imu.py
@@ -21,7 +21,12 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument("--input", type=str, default=None)
 parser.add_argument("--topic", type=str, default=None)
-parser.add_argument("--storage_id", type=str, default="mcap")
+parser.add_argument(
+    "--storage_id",
+    type=str,
+    default="",
+    help="rosbag2 storage plugin id (empty = from bag metadata.yaml)",
+)
 
 args = parser.parse_args()
 

--- a/src/allan_variance_ros2/src/AllanVarianceComputor.cpp
+++ b/src/allan_variance_ros2/src/AllanVarianceComputor.cpp
@@ -1,5 +1,6 @@
-
 #include "allan_variance_ros2/AllanVarianceComputor.hpp"
+
+#include <boost/filesystem.hpp>
 
 namespace allan_variance_ros {
 
@@ -31,7 +32,26 @@ AllanVarianceComputor::AllanVarianceComputor(rclcpp::Node* nh, std::string confi
 void AllanVarianceComputor::run(std::string bag_path) {
   RCLCPP_INFO_STREAM(rclcpp::get_logger("rclcpp"),"Processing " << bag_path << " ...");
 
-  av_output_ = std::ofstream(imu_output_file_.c_str(), std::ofstream::out);
+  const boost::filesystem::path out_file(imu_output_file_);
+  const boost::filesystem::path parent_dir = out_file.parent_path();
+  if (!parent_dir.empty()) {
+    boost::system::error_code ec;
+    boost::filesystem::create_directories(parent_dir, ec);
+    if (ec) {
+      RCLCPP_ERROR_STREAM(
+        rclcpp::get_logger("rclcpp"),
+        "Failed to create output directory " << parent_dir.string() << ": " << ec.message());
+      return;
+    }
+  }
+
+  av_output_.open(imu_output_file_.c_str(), std::ofstream::out);
+  if (!av_output_.is_open()) {
+    RCLCPP_ERROR_STREAM(
+      rclcpp::get_logger("rclcpp"),
+      "Could not open output file for writing: " << imu_output_file_);
+    return;
+  }
 
   int imu_counter = 0;
 
@@ -39,7 +59,7 @@ void AllanVarianceComputor::run(std::string bag_path) {
     
     rosbag2_storage::StorageOptions storage_options;
     storage_options.uri = bag_path;
-    storage_options.storage_id = "mcap";
+    storage_options.storage_id = "";
 
     rosbag2_cpp::ConverterOptions converter_options;
     converter_options.input_serialization_format = "cdr";

--- a/src/allan_variance_ros2/src/allan_variance.cpp
+++ b/src/allan_variance_ros2/src/allan_variance.cpp
@@ -31,7 +31,11 @@ class AllanVarianceRos2 : public rclcpp::Node
       
       double durationTime = (std::clock() - start) / (double)CLOCKS_PER_SEC;
       RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Total computation time: %f s", durationTime);
-      RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Data written to allan_variance.csv");
+      const boost::filesystem::path csv_path =
+        boost::filesystem::absolute(boost::filesystem::path(output_path) / "allan_variance.csv");
+      RCLCPP_INFO_STREAM(
+        rclcpp::get_logger("rclcpp"),
+        "Data written to " << csv_path.string());
 
     }
 
@@ -66,7 +70,7 @@ int main(int argc, char** argv) {
   }
   
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<AllanVarianceRos2>(bag_path, config_file, output_path));
+  std::make_shared<AllanVarianceRos2>(bag_path, config_file, output_path);
   rclcpp::shutdown();
   return 0;
 }

--- a/src/allan_variance_ros2/src/plot_imu.cpp
+++ b/src/allan_variance_ros2/src/plot_imu.cpp
@@ -14,7 +14,7 @@ void plot_imu(std::string bag_path, std::string imu_topic) {
     
     rosbag2_storage::StorageOptions storage_options;
     storage_options.uri = bag_path;
-    storage_options.storage_id = "mcap";
+    storage_options.storage_id = "";
 
     rosbag2_cpp::ConverterOptions converter_options;
     converter_options.input_serialization_format = "cdr";
@@ -70,9 +70,12 @@ void plot_imu(std::string bag_path, std::string imu_topic) {
       // Log data to the internal buffer.
       rec.set_time_nanos("header_timestamp", (int64_t)tCurrNanoSeconds_);
       rec.set_time_nanos("received_timestamp", msg->time_stamp);
-      rec.log("acc/x", rerun::Scalar(imu9dof_msg->linear_acceleration.x));
+      rec.log(
+        "acc/x",
+        rerun::Scalars(rerun::Collection<rerun::components::Scalar>(
+          imu9dof_msg->linear_acceleration.x)));
     }
-    rec.save((std::string)"rerun_file.rrd");
+    (void)rec.save("rerun_file.rrd");
 
     if (!rclcpp::ok())
     {


### PR DESCRIPTION
Fixes:
- rerun deprecated calls update (resolves #6)
- boost dependency missing
- .csv file not generating (resolves #5)
- ros2 node keep spinning after task is done
- remove np.float() printed in imu.yaml values

QoL:
- removed mcap hardcoded bag type and set default to "" (empty) (resolves #2)

Pipeline was tested on a .db3 bag file on ros2 humble.